### PR TITLE
Fixes for rake grade (Windows)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,8 @@ GEM
     multi_json (1.12.1)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
+    nokogiri (1.6.8.1-x86-mingw32)
+      mini_portile2 (~> 2.1.0)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.4)
@@ -160,11 +162,14 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.12)
+    sqlite3 (1.3.12-x86-mingw32)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2016.8)
+      tzinfo (>= 1.0.0)
     uglifier (3.0.3)
       execjs (>= 0.3.0, < 3)
     xpath (2.0.0)
@@ -172,6 +177,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86-mingw32
 
 DEPENDENCIES
   better_errors
@@ -191,4 +197,4 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
 
 BUNDLED WITH
-   1.13.1
+   1.13.4

--- a/lib/tasks/grade.rake
+++ b/lib/tasks/grade.rake
@@ -221,6 +221,9 @@ else
   desc "Grade project on Windows"
   task :grade do # if needed in the future, add => :environment
 
+    # Windows prep
+    `rake db:migrate RAILS_ENV=test`
+
     # Not quite right: options work, but barely
     options = {}
     OptionParser.new do |opts|
@@ -355,7 +358,7 @@ else
         rspec_output_string_doc = `bundle exec rspec --order default --format documentation --color --tty` # "--require spec_helper"?
         puts rspec_output_string_doc
       else
-        # `open #{results_url}` # FIX for Windows
+        `cmd /c start #{results_url}`
       end
     elsif res.kind_of? Net::HTTPUnprocessableEntity
       puts "- ERROR: #{res.body}"#.error_format


### PR DESCRIPTION
1. To be safe, run `rake db:migrate RAILS_ENV=test` (_based on error observed during testing_)
2. Open results page in browser using command prompt 'start' command
